### PR TITLE
DIG-2068: containers missing email on logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "v1.0.0"
+version = "v1.0.1"
 name = "candigv2_logging"
 dependencies = [
     "requests>=2.25.1",

--- a/src/candigv2_logging/logging.py
+++ b/src/candigv2_logging/logging.py
@@ -10,7 +10,7 @@ import sys
 ## Env vars for most auth methods:
 TYK_LOGIN_TARGET_URL = os.getenv("TYK_LOGIN_TARGET_URL")
 SERVICE_NAME = os.getenv("SERVICE_NAME")
-CANDIG_USER_KEY = os.getenv("CANDIG_USER_KEY", "email")
+CANDIG_USER_KEY = os.getenv("CANDIG_USER_KEY", "preferred_username")
 DEBUG_MODE = os.getenv("DEBUG_MODE")
 
 


### PR DESCRIPTION
I think that the DHDP keycloak doesn't include an `email` claim in its token, so we switched the default to `preferred_username` since that is normally the same value as `email`. For containers like Katsu that don't pass in the CANDIG_USER_KEY in their docker-compose files, the default value gets used in logging. We should use a default value for CANDIG_USER_KEY that is present in all of the jwts we know are in use.