### PR TITLE
Update requirements, version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the following to your requirements.txt:
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@develop
 ```
 
-Then add `import candigv2.logging` to your code.
+Then add `import candigv2_logging.logging` to your code.
 
 
 ## To log in a module:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,15 +3,14 @@ requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "v1.0.3"
+version = "v1.0.4"
 name = "candigv2_logging"
 dependencies = [
-    "requests>=2.25.1",
-    "pytest>=7.2.0",
-    "PyJWT>=2.6.0",
-    "cryptography>=3.4.0"
+    "requests>=2.33.1",
+    "pytest>=9.0.3",
+    "PyJWT>=2.12.0"
     ]
-requires-python = ">= 3.9"
+requires-python = ">= 3.12"
 description = "Common logging methods for CanDIGv2"
 readme = "README.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ version = "v1.0.4"
 name = "candigv2_logging"
 dependencies = [
     "requests>=2.33.1",
-    "pytest>=9.0.3",
     "PyJWT>=2.12.0"
     ]
 requires-python = ">= 3.12"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests>=2.33.1
-pytest>=9.0.3
 PyJWT>=2.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-requests==2.32.4
-pytest==8.3.3
-PyJWT==2.6.0
-cryptography>=3.4.0
+requests>=2.33.1
+pytest>=9.0.3
+PyJWT>=2.12.0


### PR DESCRIPTION
Also removed unused dependency on really old cryptography module and unused dependency on pytest.

I tested by rebuilding my stack with this branch referenced in the etc/venv/requirements.txt and in ingest and htsget’s requirements, and ran integration tests. They worked fine.